### PR TITLE
AMP-42707 - update mixpanel swift for fixing  properties not being sent issue

### DIFF
--- a/ItlyMixpanelPlugin.podspec
+++ b/ItlyMixpanelPlugin.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files   = 'MixpanelPlugin/MixpanelPlugin/**/*.{h,swift}'
   spec.frameworks  = "Foundation"
-  spec.dependency "Mixpanel-swift", "~> 2.7.0"
+  spec.dependency "Mixpanel-swift", "~> 2.10.3"
   spec.dependency "ItlySdk", "~> 1.0"
 
   spec.swift_version = '5.3'

--- a/MixpanelPlugin/Cartfile
+++ b/MixpanelPlugin/Cartfile
@@ -1,1 +1,1 @@
-github "mixpanel/mixpanel-swift" ~> 2.7
+github "mixpanel/mixpanel-swift" ~> 2.10.3

--- a/MixpanelPlugin/Cartfile.resolved
+++ b/MixpanelPlugin/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "mixpanel/mixpanel-swift" "v2.7.7"
+github "mixpanel/mixpanel-swift" "v2.10.3"


### PR DESCRIPTION
Related to Jira ticket https://amplitude.atlassian.net/browse/AMP-42707.
The bugs are fixed after update the mixpanel swift from 2.7.0 to 2.10.3
<img width="1731" alt="Screen Shot 2021-11-07 at 1 28 59 AM" src="https://user-images.githubusercontent.com/13028329/140696290-0cfaf713-8b3a-4687-b667-37a94c9beeea.png">
